### PR TITLE
Fix todo example in documentation.md

### DIFF
--- a/ja/documentation.md
+++ b/ja/documentation.md
@@ -93,7 +93,7 @@ Riot custom components are the building blocks for user interfaces. They make th
 
   <script>
     export default {
-      onBeforeMount(state, props) {
+      onBeforeMount(props, state) {
         // initial state
         this.state = {
           items: props.items,


### PR DESCRIPTION
The props and state variables were reversed in the onBeforeMount function in the todo example. Props come before state according to documentation and testing.