### PR TITLE
Fix in-browser example in compiler.md

### DIFF
--- a/compiler.md
+++ b/compiler.md
@@ -38,7 +38,7 @@ For example:
 
 <!-- compile and mount -->
 <script>
-(function async main() {
+(async function main() {
   await riot.compile()
 
   riot.mount('my-tag')


### PR DESCRIPTION
The keyword async should be before the keyword function, not after.